### PR TITLE
Added PENDING tax rate status to validation

### DIFF
--- a/accounting/lib/xero-ruby/models/tax_rate.rb
+++ b/accounting/lib/xero-ruby/models/tax_rate.rb
@@ -189,7 +189,7 @@ module XeroRuby
     # Check to see if the all the properties in the model are valid
     # @return true if the model is valid
     def valid?
-      status_validator = EnumAttributeValidator.new('String', ["ACTIVE", "DELETED", "ARCHIVED"])
+      status_validator = EnumAttributeValidator.new('String', ["ACTIVE", "DELETED", "ARCHIVED", "PENDING"])
       return false unless status_validator.valid?(@status)
       return false if @report_tax_type.nil?
       report_tax_type_validator = EnumAttributeValidator.new('String', ["OUTPUT", "INPUT", "EXEMPTOUTPUT", "INPUTTAXED", "BASEXCLUDED", "EXEMPTEXPENSES", "EXEMPTINPUT", "ECOUTPUT", "ECOUTPUTSERVICES", "ECINPUT", "ECACQUISITIONS", "CAPITALSALESOUTPUT", "CAPITALEXPENSESINPUT", "MOSSSALES", "NONE", "GSTONIMPORTS", "AVALARA"])
@@ -200,7 +200,7 @@ module XeroRuby
     # Custom attribute writer method checking allowed values (enum).
     # @param [Object] status Object to be assigned
     def status=(status)
-      validator = EnumAttributeValidator.new('String', ["ACTIVE", "DELETED", "ARCHIVED"])
+      validator = EnumAttributeValidator.new('String', ["ACTIVE", "DELETED", "ARCHIVED", "PENDING"])
       unless validator.valid?(status)
         fail ArgumentError, "invalid value for \"status\", must be one of #{validator.allowable_values}."
       end


### PR DESCRIPTION
Allow PENDING as a tax rate status, which can be returned by the API. Currently, if the organisation has a tax rate with a PENDING status, calls to the tax rates endpoint raise an error.

Resolves https://github.com/XeroAPI/xero-ruby/issues/1