### PR TITLE
Improve time zone support

### DIFF
--- a/lib/xero-ruby/models/accounting/time_zone.rb
+++ b/lib/xero-ruby/models/accounting/time_zone.rb
@@ -15,6 +15,8 @@ require 'date'
 
 module XeroRuby::Accounting
   class TimeZone
+    SIMPLISTIC_UTC_REGEXP = /UTC[+-][0-1][0-9]($|\:[0-5][0-9])/
+
     MOROCCOSTANDARDTIME = "MOROCCOSTANDARDTIME".freeze
     UTC = "UTC".freeze
     GMTSTANDARDTIME = "GMTSTANDARDTIME".freeze
@@ -83,7 +85,6 @@ module XeroRuby::Accounting
     CENTRALPACIFICSTANDARDTIME = "CENTRALPACIFICSTANDARDTIME".freeze
     RUSSIATIMEZONE11 = "RUSSIATIMEZONE11".freeze
     NEWZEALANDSTANDARDTIME = "NEWZEALANDSTANDARDTIME".freeze
-    UTC12 = "UTC+12".freeze
     FIJISTANDARDTIME = "FIJISTANDARDTIME".freeze
     KAMCHATKASTANDARDTIME = "KAMCHATKASTANDARDTIME".freeze
     TONGASTANDARDTIME = "TONGASTANDARDTIME".freeze
@@ -134,8 +135,10 @@ module XeroRuby::Accounting
     # @param [String] The enum value in the form of the string
     # @return [String] The enum value
     def build_from_hash(value)
-      constantValues = TimeZone.constants.select { |c| TimeZone::const_get(c) == value }
-      raise "Invalid ENUM value #{value} for class #TimeZone" if constantValues.empty?
+      regexp_match = SIMPLISTIC_UTC_REGEXP.match?(value)
+      valid_value  = regexp_match || TimeZone.constants.any? { |c| TimeZone::const_get(c) == value }
+
+      raise "Invalid value #{value.inspect} for class #TimeZone" unless valid_value
       value
     end
   end

--- a/spec/accounting/models/time_zone_spec.rb
+++ b/spec/accounting/models/time_zone_spec.rb
@@ -32,4 +32,28 @@ describe 'TimeZone' do
       expect(@instance).to be_instance_of(XeroRuby::Accounting::TimeZone)
     end
   end
+
+  describe 'validating constants' do
+    it 'accepts valid constant values' do
+      expect(@instance.build_from_hash('PACIFICSTANDARDTIME')).to eql('PACIFICSTANDARDTIME')
+    end
+
+    it 'prohibits invalid constant values' do
+      expect { @instance.build_from_hash('invalid') }.to raise_error(RuntimeError, 'Invalid value "invalid" for class #TimeZone')
+    end
+  end
+
+  describe 'validating UTC+/-...' do
+    it 'accepts valid UTC offsets' do
+      ['UTC', 'UTC-01', 'UTC+14', 'UTC-12', 'UTC+06', 'UTC-05:30', 'UTC+12:45'].each do |value|
+        expect(@instance.build_from_hash(value)).to eql(value)
+      end
+    end
+
+    it 'rejects invalid UTC offsets' do
+      ['UTC+', 'UTC+1', 'UTC+20', 'UTC-20', 'UTC+06:', 'UTC-05:0', 'UTC+12:60'].each do |value|
+        expect { @instance.build_from_hash(value) }.to raise_error(RuntimeError, "Invalid value #{value.inspect} for class #TimeZone")
+      end
+    end
+  end
 end

--- a/spec/api_client_spec.rb
+++ b/spec/api_client_spec.rb
@@ -10,7 +10,7 @@ OpenAPI Generator version: 4.3.0
 
 =end
 
-require './spec_helper'
+require 'spec_helper'
 
 describe XeroRuby::ApiClient do
   context 'initialization' do
@@ -139,7 +139,7 @@ describe XeroRuby::ApiClient do
           }
         ]
       }
-       
+
       json_after = {
         "LineItems":[
           {

--- a/xero-ruby.gemspec
+++ b/xero-ruby.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.summary     = "Accounting API Ruby Gem"
   s.description = "Xero API OAuth2.0 SDK - Ruby Gem"
   s.license     = "Unlicense"
-  s.required_ruby_version = ">= 1.9"
+  s.required_ruby_version = ">= 2.3"
 
   s.add_runtime_dependency 'faraday', '~> 1.0.1', '>= 1.0.1'
   s.add_runtime_dependency 'json', '~> 2.1', '>= 2.1.0'


### PR DESCRIPTION
This PR is opened as the easiest way to describe the issue & present a diff with a working solution, including tests. I'm aware that is probably not mergeable due to the use of autogenerated code in the gem.

The `TimeZone` class in the Xero Ruby gem does not work with certain responses that we see from the live Xero API during development. In particular, it is unable to properly handle `UTC+/-...` specifiers. Via a rather naïve but serviceable regex, this patch (with test coverage) handles these responses, instead of throwing a `RuntimeError`.

Note the bump to Ruby 2.3 in your `gemspec`. You rely on a minimum version of Faraday that [requires at least this Ruby version](https://github.com/lostisland/faraday/blob/ff9dc1d1219a1bbdba95a9a4cf5d135b97247ee2/faraday.gemspec), so the `1.9` specifier was outdated. By moving to 2.3, I can use `Array#any?` and improve the code's efficiency vs `Array#select` and (arguably) improve its legibility too.

The JSON response from the Xero head-end was (with privacy-sensitive entries redacted) - the most important part here is `"Timezone": "UTC+13"`.

```json
{
  "Id": "<redacted>",
  "Status": "OK",
  "ProviderName": "<redacted>",
  "DateTimeUTC": "\/Date(<redacted>)\/",
  "Organisations": [
    {
      "APIKey": "<redacted>",
      "Name": "<redacted>",
      "LegalName": "<redacted>",
      "PaysTax": true,
      "Version": "NZ",
      "OrganisationType": "COMPANY",
      "BaseCurrency": "NZD",
      "CountryCode": "NZ",
      "IsDemoCompany": false,
      "OrganisationStatus": "ACTIVE",
      "TaxNumber": "<redacted>",
      "FinancialYearEndDay": 31,
      "FinancialYearEndMonth": 3,
      "SalesTaxBasis": "PAYMENTS",
      "SalesTaxPeriod": "SIXMONTHS",
      "DefaultSalesTax": "Tax Exclusive",
      "DefaultPurchasesTax": "Tax Exclusive",
      "CreatedDateUTC": "\/Date(<redacted>)\/",
      "OrganisationEntityType": "COMPANY",
      "Timezone": "UTC+13",
      "ShortCode": "<redacted>",
      "OrganisationID": "<redacted>",
      "Edition": "BUSINESS",
      "Class": "STANDARD",
      "LineOfBusiness": "Fintech Financier",
      "Addresses": [],
      "Phones": [],
      "ExternalLinks": [],
      "PaymentTerms": {}
    }
  ]
}
```