### PR TITLE
Adds graceful time fix

### DIFF
--- a/lib/xero-ruby/models/accounting/account.rb
+++ b/lib/xero-ruby/models/accounting/account.rb
@@ -91,7 +91,7 @@ module XeroRuby::Accounting
     CISLABOURINCOME = "CISLABOURINCOME".freeze
     CISLIABILITY = "CISLIABILITY".freeze
     CISMATERIALS = "CISMATERIALS".freeze
-    # EMPTY = "".freeze
+    EMPTY = "".freeze
     
     # Shown if set
     attr_accessor :reporting_code
@@ -515,7 +515,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/account.rb
+++ b/lib/xero-ruby/models/accounting/account.rb
@@ -91,7 +91,7 @@ module XeroRuby::Accounting
     CISLABOURINCOME = "CISLABOURINCOME".freeze
     CISLIABILITY = "CISLIABILITY".freeze
     CISMATERIALS = "CISMATERIALS".freeze
-    EMPTY = "".freeze
+    # EMPTY = "".freeze
     
     # Shown if set
     attr_accessor :reporting_code

--- a/lib/xero-ruby/models/accounting/accounts.rb
+++ b/lib/xero-ruby/models/accounting/accounts.rb
@@ -204,7 +204,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/accounts_payable.rb
+++ b/lib/xero-ruby/models/accounting/accounts_payable.rb
@@ -212,7 +212,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/accounts_receivable.rb
+++ b/lib/xero-ruby/models/accounting/accounts_receivable.rb
@@ -212,7 +212,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/address.rb
+++ b/lib/xero-ruby/models/accounting/address.rb
@@ -464,7 +464,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/allocation.rb
+++ b/lib/xero-ruby/models/accounting/allocation.rb
@@ -289,7 +289,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/allocations.rb
+++ b/lib/xero-ruby/models/accounting/allocations.rb
@@ -204,7 +204,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/attachment.rb
+++ b/lib/xero-ruby/models/accounting/attachment.rb
@@ -252,7 +252,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/attachments.rb
+++ b/lib/xero-ruby/models/accounting/attachments.rb
@@ -204,7 +204,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/balances.rb
+++ b/lib/xero-ruby/models/accounting/balances.rb
@@ -213,7 +213,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/bank_transaction.rb
+++ b/lib/xero-ruby/models/accounting/bank_transaction.rb
@@ -490,7 +490,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/bank_transactions.rb
+++ b/lib/xero-ruby/models/accounting/bank_transactions.rb
@@ -204,7 +204,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/bank_transfer.rb
+++ b/lib/xero-ruby/models/accounting/bank_transfer.rb
@@ -321,7 +321,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/bank_transfers.rb
+++ b/lib/xero-ruby/models/accounting/bank_transfers.rb
@@ -204,7 +204,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/batch_payment.rb
+++ b/lib/xero-ruby/models/accounting/batch_payment.rb
@@ -464,7 +464,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/batch_payment_details.rb
+++ b/lib/xero-ruby/models/accounting/batch_payment_details.rb
@@ -288,7 +288,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/batch_payments.rb
+++ b/lib/xero-ruby/models/accounting/batch_payments.rb
@@ -204,7 +204,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/bill.rb
+++ b/lib/xero-ruby/models/accounting/bill.rb
@@ -212,7 +212,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/branding_theme.rb
+++ b/lib/xero-ruby/models/accounting/branding_theme.rb
@@ -287,7 +287,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/branding_themes.rb
+++ b/lib/xero-ruby/models/accounting/branding_themes.rb
@@ -204,7 +204,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/cis_org_setting.rb
+++ b/lib/xero-ruby/models/accounting/cis_org_setting.rb
@@ -222,7 +222,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/cis_setting.rb
+++ b/lib/xero-ruby/models/accounting/cis_setting.rb
@@ -212,7 +212,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/cis_settings.rb
+++ b/lib/xero-ruby/models/accounting/cis_settings.rb
@@ -204,7 +204,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/contact.rb
+++ b/lib/xero-ruby/models/accounting/contact.rb
@@ -744,7 +744,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/contact_group.rb
+++ b/lib/xero-ruby/models/accounting/contact_group.rb
@@ -270,7 +270,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/contact_groups.rb
+++ b/lib/xero-ruby/models/accounting/contact_groups.rb
@@ -204,7 +204,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/contact_person.rb
+++ b/lib/xero-ruby/models/accounting/contact_person.rb
@@ -232,7 +232,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/contacts.rb
+++ b/lib/xero-ruby/models/accounting/contacts.rb
@@ -204,7 +204,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/credit_note.rb
+++ b/lib/xero-ruby/models/accounting/credit_note.rb
@@ -518,7 +518,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/credit_notes.rb
+++ b/lib/xero-ruby/models/accounting/credit_notes.rb
@@ -204,7 +204,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/currencies.rb
+++ b/lib/xero-ruby/models/accounting/currencies.rb
@@ -204,7 +204,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/currency.rb
+++ b/lib/xero-ruby/models/accounting/currency.rb
@@ -212,7 +212,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/currency_code.rb
+++ b/lib/xero-ruby/models/accounting/currency_code.rb
@@ -154,7 +154,7 @@ module XeroRuby::Accounting
     TMT = "TMT".freeze
     TND = "TND".freeze
     TOP = "TOP".freeze
-    _TRY = "TRY".freeze
+    TRY = "TRY".freeze
     TTD = "TTD".freeze
     TVD = "TVD".freeze
     TWD = "TWD".freeze
@@ -178,7 +178,7 @@ module XeroRuby::Accounting
     ZMW = "ZMW".freeze
     ZMK = "ZMK".freeze
     ZWD = "ZWD".freeze
-    _EMPTY = "".freeze
+    EMPTY = "".freeze
 
     # Builds the enum from string
     # @param [String] The enum value in the form of the string

--- a/lib/xero-ruby/models/accounting/currency_code.rb
+++ b/lib/xero-ruby/models/accounting/currency_code.rb
@@ -39,6 +39,7 @@ module XeroRuby::Accounting
     BTN = "BTN".freeze
     BWP = "BWP".freeze
     BYN = "BYN".freeze
+    BYR = "BYR".freeze
     BZD = "BZD".freeze
     CAD = "CAD".freeze
     CDF = "CDF".freeze
@@ -100,6 +101,7 @@ module XeroRuby::Accounting
     LKR = "LKR".freeze
     LRD = "LRD".freeze
     LSL = "LSL".freeze
+    LTL = "LTL".freeze
     LYD = "LYD".freeze
     MAD = "MAD".freeze
     MDL = "MDL".freeze

--- a/lib/xero-ruby/models/accounting/currency_code.rb
+++ b/lib/xero-ruby/models/accounting/currency_code.rb
@@ -39,7 +39,6 @@ module XeroRuby::Accounting
     BTN = "BTN".freeze
     BWP = "BWP".freeze
     BYN = "BYN".freeze
-    BYR = "BYR".freeze
     BZD = "BZD".freeze
     CAD = "CAD".freeze
     CDF = "CDF".freeze
@@ -101,7 +100,6 @@ module XeroRuby::Accounting
     LKR = "LKR".freeze
     LRD = "LRD".freeze
     LSL = "LSL".freeze
-    LTL = "LTL".freeze
     LYD = "LYD".freeze
     MAD = "MAD".freeze
     MDL = "MDL".freeze
@@ -156,7 +154,7 @@ module XeroRuby::Accounting
     TMT = "TMT".freeze
     TND = "TND".freeze
     TOP = "TOP".freeze
-    TRY = "TRY".freeze
+    _TRY = "TRY".freeze
     TTD = "TTD".freeze
     TVD = "TVD".freeze
     TWD = "TWD".freeze
@@ -180,7 +178,7 @@ module XeroRuby::Accounting
     ZMW = "ZMW".freeze
     ZMK = "ZMK".freeze
     ZWD = "ZWD".freeze
-    EMPTY = "".freeze
+    _EMPTY = "".freeze
 
     # Builds the enum from string
     # @param [String] The enum value in the form of the string

--- a/lib/xero-ruby/models/accounting/element.rb
+++ b/lib/xero-ruby/models/accounting/element.rb
@@ -274,7 +274,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/employee.rb
+++ b/lib/xero-ruby/models/accounting/employee.rb
@@ -342,7 +342,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/employees.rb
+++ b/lib/xero-ruby/models/accounting/employees.rb
@@ -204,7 +204,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/error.rb
+++ b/lib/xero-ruby/models/accounting/error.rb
@@ -234,7 +234,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/expense_claim.rb
+++ b/lib/xero-ruby/models/accounting/expense_claim.rb
@@ -355,7 +355,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/expense_claims.rb
+++ b/lib/xero-ruby/models/accounting/expense_claims.rb
@@ -204,7 +204,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/external_link.rb
+++ b/lib/xero-ruby/models/accounting/external_link.rb
@@ -261,7 +261,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/history_record.rb
+++ b/lib/xero-ruby/models/accounting/history_record.rb
@@ -232,7 +232,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/history_records.rb
+++ b/lib/xero-ruby/models/accounting/history_records.rb
@@ -204,7 +204,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/invoice.rb
+++ b/lib/xero-ruby/models/accounting/invoice.rb
@@ -692,7 +692,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/invoice_reminder.rb
+++ b/lib/xero-ruby/models/accounting/invoice_reminder.rb
@@ -202,7 +202,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/invoice_reminders.rb
+++ b/lib/xero-ruby/models/accounting/invoice_reminders.rb
@@ -204,7 +204,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/invoices.rb
+++ b/lib/xero-ruby/models/accounting/invoices.rb
@@ -204,7 +204,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/item.rb
+++ b/lib/xero-ruby/models/accounting/item.rb
@@ -423,7 +423,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/items.rb
+++ b/lib/xero-ruby/models/accounting/items.rb
@@ -204,7 +204,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/journal.rb
+++ b/lib/xero-ruby/models/accounting/journal.rb
@@ -333,7 +333,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/journal_line.rb
+++ b/lib/xero-ruby/models/accounting/journal_line.rb
@@ -314,7 +314,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/journals.rb
+++ b/lib/xero-ruby/models/accounting/journals.rb
@@ -204,7 +204,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/line_item.rb
+++ b/lib/xero-ruby/models/accounting/line_item.rb
@@ -324,7 +324,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/line_item_tracking.rb
+++ b/lib/xero-ruby/models/accounting/line_item_tracking.rb
@@ -247,7 +247,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/linked_transaction.rb
+++ b/lib/xero-ruby/models/accounting/linked_transaction.rb
@@ -370,7 +370,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/linked_transactions.rb
+++ b/lib/xero-ruby/models/accounting/linked_transactions.rb
@@ -204,7 +204,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/manual_journal.rb
+++ b/lib/xero-ruby/models/accounting/manual_journal.rb
@@ -386,7 +386,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/manual_journal_line.rb
+++ b/lib/xero-ruby/models/accounting/manual_journal_line.rb
@@ -274,7 +274,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/manual_journals.rb
+++ b/lib/xero-ruby/models/accounting/manual_journals.rb
@@ -204,7 +204,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/online_invoice.rb
+++ b/lib/xero-ruby/models/accounting/online_invoice.rb
@@ -202,7 +202,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/online_invoices.rb
+++ b/lib/xero-ruby/models/accounting/online_invoices.rb
@@ -204,7 +204,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/organisation.rb
+++ b/lib/xero-ruby/models/accounting/organisation.rb
@@ -114,7 +114,7 @@ module XeroRuby::Accounting
     N6_MONTHLY = "6MONTHLY".freeze
     QUARTERLY = "QUARTERLY".freeze
     YEARLY = "YEARLY".freeze
-    NONE = "NONE".freeze
+    # NONE = "NONE".freeze
     
     # The default for LineAmountTypes on sales transactions
     attr_accessor :default_sales_tax
@@ -136,18 +136,18 @@ module XeroRuby::Accounting
     
     # Organisation Entity Type
     attr_accessor :organisation_entity_type
-    ACCOUNTING_PRACTICE = "ACCOUNTING_PRACTICE".freeze
-    COMPANY = "COMPANY".freeze
-    CHARITY = "CHARITY".freeze
-    CLUB_OR_SOCIETY = "CLUB_OR_SOCIETY".freeze
-    LOOK_THROUGH_COMPANY = "LOOK_THROUGH_COMPANY".freeze
-    NOT_FOR_PROFIT = "NOT_FOR_PROFIT".freeze
-    PARTNERSHIP = "PARTNERSHIP".freeze
-    S_CORPORATION = "S_CORPORATION".freeze
-    SELF_MANAGED_SUPERANNUATION_FUND = "SELF_MANAGED_SUPERANNUATION_FUND".freeze
-    SOLE_TRADER = "SOLE_TRADER".freeze
-    SUPERANNUATION_FUND = "SUPERANNUATION_FUND".freeze
-    TRUST = "TRUST".freeze
+    # ACCOUNTING_PRACTICE = "ACCOUNTING_PRACTICE".freeze
+    # COMPANY = "COMPANY".freeze
+    # CHARITY = "CHARITY".freeze
+    # CLUB_OR_SOCIETY = "CLUB_OR_SOCIETY".freeze
+    # LOOK_THROUGH_COMPANY = "LOOK_THROUGH_COMPANY".freeze
+    # NOT_FOR_PROFIT = "NOT_FOR_PROFIT".freeze
+    # PARTNERSHIP = "PARTNERSHIP".freeze
+    # S_CORPORATION = "S_CORPORATION".freeze
+    # SELF_MANAGED_SUPERANNUATION_FUND = "SELF_MANAGED_SUPERANNUATION_FUND".freeze
+    # SOLE_TRADER = "SOLE_TRADER".freeze
+    # SUPERANNUATION_FUND = "SUPERANNUATION_FUND".freeze
+    # TRUST = "TRUST".freeze
     
     # A unique identifier for the organisation. Potential uses.
     attr_accessor :short_code

--- a/lib/xero-ruby/models/accounting/organisation.rb
+++ b/lib/xero-ruby/models/accounting/organisation.rb
@@ -114,7 +114,7 @@ module XeroRuby::Accounting
     N6_MONTHLY = "6MONTHLY".freeze
     QUARTERLY = "QUARTERLY".freeze
     YEARLY = "YEARLY".freeze
-    # NONE = "NONE".freeze
+    NONE = "NONE".freeze
     
     # The default for LineAmountTypes on sales transactions
     attr_accessor :default_sales_tax
@@ -136,18 +136,18 @@ module XeroRuby::Accounting
     
     # Organisation Entity Type
     attr_accessor :organisation_entity_type
-    # ACCOUNTING_PRACTICE = "ACCOUNTING_PRACTICE".freeze
-    # COMPANY = "COMPANY".freeze
-    # CHARITY = "CHARITY".freeze
-    # CLUB_OR_SOCIETY = "CLUB_OR_SOCIETY".freeze
-    # LOOK_THROUGH_COMPANY = "LOOK_THROUGH_COMPANY".freeze
-    # NOT_FOR_PROFIT = "NOT_FOR_PROFIT".freeze
-    # PARTNERSHIP = "PARTNERSHIP".freeze
-    # S_CORPORATION = "S_CORPORATION".freeze
-    # SELF_MANAGED_SUPERANNUATION_FUND = "SELF_MANAGED_SUPERANNUATION_FUND".freeze
-    # SOLE_TRADER = "SOLE_TRADER".freeze
-    # SUPERANNUATION_FUND = "SUPERANNUATION_FUND".freeze
-    # TRUST = "TRUST".freeze
+    ACCOUNTING_PRACTICE = "ACCOUNTING_PRACTICE".freeze
+    COMPANY = "COMPANY".freeze
+    CHARITY = "CHARITY".freeze
+    CLUB_OR_SOCIETY = "CLUB_OR_SOCIETY".freeze
+    LOOK_THROUGH_COMPANY = "LOOK_THROUGH_COMPANY".freeze
+    NOT_FOR_PROFIT = "NOT_FOR_PROFIT".freeze
+    PARTNERSHIP = "PARTNERSHIP".freeze
+    S_CORPORATION = "S_CORPORATION".freeze
+    SELF_MANAGED_SUPERANNUATION_FUND = "SELF_MANAGED_SUPERANNUATION_FUND".freeze
+    SOLE_TRADER = "SOLE_TRADER".freeze
+    SUPERANNUATION_FUND = "SUPERANNUATION_FUND".freeze
+    TRUST = "TRUST".freeze
     
     # A unique identifier for the organisation. Potential uses.
     attr_accessor :short_code
@@ -704,7 +704,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/organisations.rb
+++ b/lib/xero-ruby/models/accounting/organisations.rb
@@ -204,7 +204,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/overpayment.rb
+++ b/lib/xero-ruby/models/accounting/overpayment.rb
@@ -444,7 +444,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/overpayments.rb
+++ b/lib/xero-ruby/models/accounting/overpayments.rb
@@ -204,7 +204,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/payment.rb
+++ b/lib/xero-ruby/models/accounting/payment.rb
@@ -494,7 +494,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/payment_delete.rb
+++ b/lib/xero-ruby/models/accounting/payment_delete.rb
@@ -209,7 +209,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/payment_service.rb
+++ b/lib/xero-ruby/models/accounting/payment_service.rb
@@ -254,7 +254,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/payment_services.rb
+++ b/lib/xero-ruby/models/accounting/payment_services.rb
@@ -204,7 +204,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/payment_term.rb
+++ b/lib/xero-ruby/models/accounting/payment_term.rb
@@ -212,7 +212,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/payments.rb
+++ b/lib/xero-ruby/models/accounting/payments.rb
@@ -204,7 +204,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/phone.rb
+++ b/lib/xero-ruby/models/accounting/phone.rb
@@ -316,7 +316,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/prepayment.rb
+++ b/lib/xero-ruby/models/accounting/prepayment.rb
@@ -443,7 +443,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/prepayments.rb
+++ b/lib/xero-ruby/models/accounting/prepayments.rb
@@ -204,7 +204,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/purchase.rb
+++ b/lib/xero-ruby/models/accounting/purchase.rb
@@ -232,7 +232,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/purchase_order.rb
+++ b/lib/xero-ruby/models/accounting/purchase_order.rb
@@ -521,7 +521,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/purchase_orders.rb
+++ b/lib/xero-ruby/models/accounting/purchase_orders.rb
@@ -204,7 +204,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/quote.rb
+++ b/lib/xero-ruby/models/accounting/quote.rb
@@ -511,7 +511,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/quotes.rb
+++ b/lib/xero-ruby/models/accounting/quotes.rb
@@ -204,7 +204,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/receipt.rb
+++ b/lib/xero-ruby/models/accounting/receipt.rb
@@ -421,7 +421,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/receipts.rb
+++ b/lib/xero-ruby/models/accounting/receipts.rb
@@ -204,7 +204,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/repeating_invoice.rb
+++ b/lib/xero-ruby/models/accounting/repeating_invoice.rb
@@ -409,7 +409,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/repeating_invoices.rb
+++ b/lib/xero-ruby/models/accounting/repeating_invoices.rb
@@ -204,7 +204,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/report.rb
+++ b/lib/xero-ruby/models/accounting/report.rb
@@ -299,7 +299,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/report_attribute.rb
+++ b/lib/xero-ruby/models/accounting/report_attribute.rb
@@ -212,7 +212,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/report_cell.rb
+++ b/lib/xero-ruby/models/accounting/report_cell.rb
@@ -214,7 +214,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/report_fields.rb
+++ b/lib/xero-ruby/models/accounting/report_fields.rb
@@ -222,7 +222,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/report_row.rb
+++ b/lib/xero-ruby/models/accounting/report_row.rb
@@ -224,7 +224,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/report_rows.rb
+++ b/lib/xero-ruby/models/accounting/report_rows.rb
@@ -236,7 +236,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/report_with_row.rb
+++ b/lib/xero-ruby/models/accounting/report_with_row.rb
@@ -288,7 +288,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/report_with_rows.rb
+++ b/lib/xero-ruby/models/accounting/report_with_rows.rb
@@ -204,7 +204,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/reports.rb
+++ b/lib/xero-ruby/models/accounting/reports.rb
@@ -204,7 +204,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/request_empty.rb
+++ b/lib/xero-ruby/models/accounting/request_empty.rb
@@ -202,7 +202,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/sales_tracking_category.rb
+++ b/lib/xero-ruby/models/accounting/sales_tracking_category.rb
@@ -212,7 +212,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/schedule.rb
+++ b/lib/xero-ruby/models/accounting/schedule.rb
@@ -316,7 +316,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/tax_component.rb
+++ b/lib/xero-ruby/models/accounting/tax_component.rb
@@ -232,7 +232,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/tax_rate.rb
+++ b/lib/xero-ruby/models/accounting/tax_rate.rb
@@ -438,7 +438,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/tax_rates.rb
+++ b/lib/xero-ruby/models/accounting/tax_rates.rb
@@ -204,7 +204,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/ten_ninety_nine_contact.rb
+++ b/lib/xero-ruby/models/accounting/ten_ninety_nine_contact.rb
@@ -412,7 +412,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/tracking_categories.rb
+++ b/lib/xero-ruby/models/accounting/tracking_categories.rb
@@ -204,7 +204,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/tracking_category.rb
+++ b/lib/xero-ruby/models/accounting/tracking_category.rb
@@ -321,7 +321,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/tracking_option.rb
+++ b/lib/xero-ruby/models/accounting/tracking_option.rb
@@ -284,7 +284,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/tracking_options.rb
+++ b/lib/xero-ruby/models/accounting/tracking_options.rb
@@ -204,7 +204,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/user.rb
+++ b/lib/xero-ruby/models/accounting/user.rb
@@ -303,7 +303,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/users.rb
+++ b/lib/xero-ruby/models/accounting/users.rb
@@ -204,7 +204,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/accounting/validation_error.rb
+++ b/lib/xero-ruby/models/accounting/validation_error.rb
@@ -202,7 +202,7 @@ module XeroRuby::Accounting
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/assets/asset.rb
+++ b/lib/xero-ruby/models/assets/asset.rb
@@ -347,7 +347,7 @@ module XeroRuby::Assets
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/assets/asset_type.rb
+++ b/lib/xero-ruby/models/assets/asset_type.rb
@@ -272,7 +272,7 @@ module XeroRuby::Assets
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/assets/assets.rb
+++ b/lib/xero-ruby/models/assets/assets.rb
@@ -214,7 +214,7 @@ module XeroRuby::Assets
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/assets/book_depreciation_detail.rb
+++ b/lib/xero-ruby/models/assets/book_depreciation_detail.rb
@@ -262,7 +262,7 @@ module XeroRuby::Assets
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/assets/book_depreciation_setting.rb
+++ b/lib/xero-ruby/models/assets/book_depreciation_setting.rb
@@ -341,7 +341,7 @@ module XeroRuby::Assets
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/assets/error.rb
+++ b/lib/xero-ruby/models/assets/error.rb
@@ -246,7 +246,7 @@ module XeroRuby::Assets
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/assets/field_validation_errors_element.rb
+++ b/lib/xero-ruby/models/assets/field_validation_errors_element.rb
@@ -252,7 +252,7 @@ module XeroRuby::Assets
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/assets/pagination.rb
+++ b/lib/xero-ruby/models/assets/pagination.rb
@@ -232,7 +232,7 @@ module XeroRuby::Assets
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/assets/resource_validation_errors_element.rb
+++ b/lib/xero-ruby/models/assets/resource_validation_errors_element.rb
@@ -242,7 +242,7 @@ module XeroRuby::Assets
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/assets/setting.rb
+++ b/lib/xero-ruby/models/assets/setting.rb
@@ -272,7 +272,7 @@ module XeroRuby::Assets
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/projects/amount.rb
+++ b/lib/xero-ruby/models/projects/amount.rb
@@ -212,7 +212,7 @@ module XeroRuby::Projects
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/projects/error.rb
+++ b/lib/xero-ruby/models/projects/error.rb
@@ -212,7 +212,7 @@ module XeroRuby::Projects
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/projects/pagination.rb
+++ b/lib/xero-ruby/models/projects/pagination.rb
@@ -232,7 +232,7 @@ module XeroRuby::Projects
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/projects/project.rb
+++ b/lib/xero-ruby/models/projects/project.rb
@@ -417,7 +417,7 @@ module XeroRuby::Projects
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/projects/project_create_or_update.rb
+++ b/lib/xero-ruby/models/projects/project_create_or_update.rb
@@ -237,7 +237,7 @@ module XeroRuby::Projects
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/projects/project_patch.rb
+++ b/lib/xero-ruby/models/projects/project_patch.rb
@@ -207,7 +207,7 @@ module XeroRuby::Projects
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/projects/project_user.rb
+++ b/lib/xero-ruby/models/projects/project_user.rb
@@ -222,7 +222,7 @@ module XeroRuby::Projects
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/projects/project_users.rb
+++ b/lib/xero-ruby/models/projects/project_users.rb
@@ -214,7 +214,7 @@ module XeroRuby::Projects
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/projects/projects.rb
+++ b/lib/xero-ruby/models/projects/projects.rb
@@ -214,7 +214,7 @@ module XeroRuby::Projects
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/projects/task.rb
+++ b/lib/xero-ruby/models/projects/task.rb
@@ -379,7 +379,7 @@ module XeroRuby::Projects
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/projects/task_create_or_update.rb
+++ b/lib/xero-ruby/models/projects/task_create_or_update.rb
@@ -247,7 +247,7 @@ module XeroRuby::Projects
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/projects/tasks.rb
+++ b/lib/xero-ruby/models/projects/tasks.rb
@@ -214,7 +214,7 @@ module XeroRuby::Projects
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/projects/time_entries.rb
+++ b/lib/xero-ruby/models/projects/time_entries.rb
@@ -214,7 +214,7 @@ module XeroRuby::Projects
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/projects/time_entry.rb
+++ b/lib/xero-ruby/models/projects/time_entry.rb
@@ -318,7 +318,7 @@ module XeroRuby::Projects
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end

--- a/lib/xero-ruby/models/projects/time_entry_create_or_update.rb
+++ b/lib/xero-ruby/models/projects/time_entry_create_or_update.rb
@@ -262,7 +262,7 @@ module XeroRuby::Projects
     # customized data_parser
     def parse_date(datestring)
       seconds_since_epoch = datestring.scan(/[0-9]+/)[0].to_i / 1000.0
-      return Time.at(seconds_since_epoch).to_s
+      return Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z').to_s
     end
   end
 end


### PR DESCRIPTION
Graceful handling of date parsing in case anyone overrides it in their rails config it won't break the date parsing / deserialization

Time.at(seconds_since_epoch).strftime('%Y-%m-%dT%l:%M:%S%z')
