### PR TITLE
Adds state in url params

### DIFF
--- a/lib/xero-ruby/api_client.rb
+++ b/lib/xero-ruby/api_client.rb
@@ -34,6 +34,7 @@ module XeroRuby
       @client_secret = credentials[:client_secret]
       @redirect_uri = credentials[:redirect_uri]
       @scopes = credentials[:scopes]
+      @state = credentials[:state]
       @config = config
       @user_agent = "xero-ruby-#{VERSION}"
       @default_headers = {
@@ -43,7 +44,7 @@ module XeroRuby
     end
 
     def authorization_url
-      url = "#{@config.login_url}?response_type=code&client_id=#{@client_id}&redirect_uri=#{@redirect_uri}&scope=#{@scopes}"
+      url = "#{@config.login_url}?response_type=code&client_id=#{@client_id}&redirect_uri=#{@redirect_uri}&scope=#{@scopes}&state=#{@state}"
       return url
     end
 
@@ -76,7 +77,7 @@ module XeroRuby
       @config.base_url = @config.payroll_nz_url
       XeroRuby::PayrollNzApi.new(self)
     end
-    
+
     def payroll_uk_api
       @config.base_url = @config.payroll_uk_url
       XeroRuby::PayrollUkApi.new(self)


### PR DESCRIPTION
Hello!

I was trying to make the authentication work with subdomains.
Unfortunately xero does not officially support wildcard subdomains.

After some searching i figured that there is a state parameter offered in which we can pass our subdomain and handle it on the redirect callback. Since this this implementation did not include the state parameter i decided to add it, as i believe it will help people with similar cases with mine.