### PR TITLE
Add support for string operators in where options

### DIFF
--- a/lib/xero-ruby.rb
+++ b/lib/xero-ruby.rb
@@ -10,6 +10,8 @@ OpenAPI Generator version: 4.3.1
 =end
 
 # Common files
+require 'xero-ruby/string_serialization'
+require 'xero-ruby/where'
 require 'xero-ruby/api_client'
 require 'xero-ruby/api_error'
 require 'xero-ruby/version'

--- a/lib/xero-ruby/string_serialization.rb
+++ b/lib/xero-ruby/string_serialization.rb
@@ -1,0 +1,52 @@
+module XeroRuby
+  module StringSerialization
+    # START - Re-serializes snake_cased params to PascalCase required by XeroAPI
+    def to_camel_keys(value = self)
+      case value
+      when Array
+        value.map { |v| to_camel_keys(v) }
+      when Hash
+        Hash[value.map { |k, v| [camelize_key(k), to_camel_keys(v)] }]
+      else
+        value
+      end
+    end
+
+    def camelize_key(key, first_upper = true)
+      if key.is_a? Symbol
+        camelize(key.to_s, first_upper).to_sym
+      elsif key.is_a? String
+        camelize(key, first_upper)
+      else
+        key # can't camelize anything except strings and symbols
+      end
+    end
+
+    def camelize(word, first_upper = true)
+      if first_upper
+        str = word.to_s
+        str = gsubbed(str, /(?:^|_)([^_\s]+)/)
+        str = gsubbed(str, %r{/([^/]*)}, "::")
+        str
+      else
+        parts = word.split("_", 2)
+        parts[0] << camelize(parts[1]) if parts.size > 1
+        parts[0] || ""
+      end
+    end
+
+    def gsubbed(str, pattern, extra = "")
+      key_map_scronyms = {}
+      str = str.gsub(pattern) do
+        extra + (key_map_scronyms[Regexp.last_match(1)] || capitalize_first(Regexp.last_match(1)))
+      end
+      str
+    end
+
+    def capitalize_first(word)
+      split = word.split('')
+      "#{split[0].capitalize}#{split[1..-1].join}"
+    end
+    # END - Re-serializes snake_cased params to PascalCase required by XeroAPI
+  end
+end

--- a/lib/xero-ruby/where.rb
+++ b/lib/xero-ruby/where.rb
@@ -1,0 +1,65 @@
+module XeroRuby
+  class Where
+    include StringSerialization
+
+    UUID_REGEXP = /\A[0-9a-f]{8}\b-[0-9a-f]{4}\b-[0-9a-f]{4}\b-[0-9a-f]{4}\b-[0-9a-f]{12}\Z/i
+    STRING_FUNCTIONS = %w(Contains StartsWith EndsWith)
+
+    attr_reader :where_opts
+
+    def initialize(where_opts)
+      @where_opts = where_opts
+    end
+
+    def to_param
+      where_opts.map { |key, value| parameterize_option(key, value) }.join(' AND ')
+    end
+
+    private
+
+    def parameterize_option(key, value)
+      quoted_key = quote_key(key)
+
+      case value
+      when Array
+        operator, query = value
+
+        if STRING_FUNCTIONS.include?(camelize_key(operator))
+          "#{quoted_key}.#{camelize_key(operator)}(#{quote_value(query)})"
+        else
+          "#{quoted_key} #{operator} #{quote_value(query)}"
+        end
+      when Range
+        "#{quoted_key} >= #{quote_value(value.first)} AND #{quoted_key} <= #{quote_value(value.last)}"
+      when /^\./
+        "#{quoted_key}#{value}"
+      else
+        "#{quoted_key} #{value}"
+      end
+    end
+
+    def quote_key(key)
+      case key
+      when :contact_id
+        'Contact.ContactID'
+      when :contact_number
+        'Contact.ContactNumber'
+      else
+        camelize_key(key)
+      end
+    end
+
+    def quote_value(value)
+      case value
+      when DateTime, Date, Time
+        "DateTime(#{value.strftime("%Y,%m,%d")})"
+      when Numeric, false, true
+        value.to_s
+      when UUID_REGEXP
+        %{guid("#{value}")}
+      else
+        %{"#{value.to_s.gsub('"', '""')}"}
+      end
+    end
+  end
+end

--- a/spec/where_spec.rb
+++ b/spec/where_spec.rb
@@ -1,0 +1,82 @@
+require 'spec_helper'
+
+describe XeroRuby::Where do
+  let(:query) { described_class.new(opts) }
+
+  subject { query.to_param }
+
+  describe "arrays" do
+    describe "a simple equality test" do
+      let(:opts) { { test_field: ['=', 'test'] } }
+
+      it { is_expected.to eq %{TestField = "test"} }
+    end
+
+    describe "a test with a date" do
+      let(:opts) { { test: ['=', Date.parse('2020-02-01')] } }
+
+      it { is_expected.to eq %{Test = DateTime(2020,02,01)} }
+    end
+
+    describe "multiple options" do
+      let(:opts) { { a: ['=', 1], b: ['=', 2] } }
+
+      it { is_expected.to eq %{A = 1 AND B = 2} }
+    end
+
+    describe "special keys" do
+      let(:opts) { { contact_id: 3, contact_number: 4 } }
+
+      it { is_expected.to eq %{Contact.ContactID 3 AND Contact.ContactNumber 4} }
+    end
+
+    describe "string functions" do
+      let(:opts) { { name: ['Contains', 'ero'] } }
+
+      it { is_expected.to eq %{Name.Contains("ero")} }
+    end
+
+    describe "special characters in the search string" do
+      let(:opts) { { a: ['=', 'quote"quote'] } }
+
+      it { is_expected.to eq %{A = "quote""quote"} }
+    end
+
+    describe "numbers" do
+      let(:opts) { { a: ['=', 10], b: ['=', 20.5] } }
+
+      it { is_expected.to eq %{A = 10 AND B = 20.5} }
+    end
+
+    describe "booleans" do
+      let(:opts) { { a: ['=', false], b: ['=', true] } }
+
+      it { is_expected.to eq %{A = false AND B = true} }
+    end
+
+    describe "UUIDs" do
+      let (:opts) { { a: ['=', '62c54cf8-eb9a-450e-8ca2-bb1fa9237940'] } }
+
+      it { is_expected.to eq %{A = guid("62c54cf8-eb9a-450e-8ca2-bb1fa9237940")} }
+    end
+  end
+
+  describe "ranges" do
+    let(:range) { Date.parse('2020-02-01')..Date.parse('2020-02-15') }
+    let(:opts) { { a: range } }
+
+    it { is_expected.to eq %{A >= DateTime(2020,02,01) AND A <= DateTime(2020,02,15)} }
+  end
+
+  describe "operators starting with a dot" do
+    let(:opts) { {a: '.Test("Hello")' } }
+
+    it { is_expected.to eq %{A.Test("Hello")} }
+  end
+
+  describe "unmatched operators" do
+    let(:opts) { {a: 'something unusual'} }
+
+    it { is_expected.to eq %{A something unusual} }
+  end
+end


### PR DESCRIPTION
Hi team, I wanted to use the .Contains operator in the where clause, and noticed the API didn't allow that.

While adding that function I extracted the where parsing logic to a separate file, made it a bit more robust and easy to follow (for example, I added quoting to strings—in the current code if the value is user-controlled, they could cause an error by including a double quote in their value.)  There weren't any tests in the original code either, so I wrote some of those.

I've pulled the camelization methods out into a module too so they can be shared across multiple classes.  I didn't touch any of those, just a straight copy-paste from api-client.rb.

Happy to make any changes based on your feedback!