### PR TITLE
Reverses logic in README token_expired? example

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ require 'jwt'
 
 def token_expired?
   token_expiry = Time.at(decoded_access_token['exp'])
-  token_expiry > Time.now
+  token_expiry < Time.now
 end
 
 def decoded_access_token


### PR DESCRIPTION
The `token_expired?` example in the readme returns `true` when the
token is *not* expired (token_expiry is in the future), but should
return `false`.