### PR TITLE
Remove use of blank?

### DIFF
--- a/lib/xero-ruby/api_client.rb
+++ b/lib/xero-ruby/api_client.rb
@@ -136,7 +136,7 @@ module XeroRuby
         req.body = URI.encode_www_form(data)
       end
       return_error(response) unless response.success?
-      if !response.body.blank?
+      if !response.body.nil? && !response.body.empty?
         body = JSON.parse(response.body)
         set_token_set(body)
       else


### PR DESCRIPTION
Although really useful, `blank?` is a Rails-specific method. So, if you use this library from a simple Ruby app or script, it will fail.

This simple script fails:

```ruby
xero_client = XeroRuby::ApiClient.new

token_set = xero_client.refresh_token_set(token_set)
```

with this error:

```
undefined method `blank?' for #<String:0x00005645e64da800> (NoMethodError)
```