### PR TITLE
Explicitly require Base64 library

### DIFF
--- a/lib/xero-ruby/api_client.rb
+++ b/lib/xero-ruby/api_client.rb
@@ -15,6 +15,7 @@ require 'logger'
 require 'tempfile'
 require 'find'
 require 'faraday'
+require 'base64'
 
 module XeroRuby
   class ApiClient


### PR DESCRIPTION
`XeroRuby::ApiClient#token_request` raises the following error on a Ruby app/script:

```
uninitialized constant XeroRuby::ApiClient::Base64 (NameError)
```

I guess that this is fine for Rails users as Base64 is preloaded by default.