### PR TITLE
Get rid of `GCI.escape` in `authorization_url`

### DIFF
--- a/lib/xero-ruby/api_client.rb
+++ b/lib/xero-ruby/api_client.rb
@@ -57,9 +57,17 @@ module XeroRuby
     end
 
     def authorization_url
-      url = "#{@config.login_url}?response_type=code&client_id=#{@client_id}&redirect_uri=#{@redirect_uri}&scope=#{CGI.escape(@scopes)}"
-      url << "&state=#{@state}" if @state
-      return url
+      url = URI.parse @config.login_url
+      url.query = URI.encode_www_form(
+        {
+          response_type: 'code',
+          client_id: @client_id,
+          redirect_uri: @redirect_uri,
+          scope: @scopes,
+          state: @state
+        }.compact
+      )
+      url.to_s
     end
 
     def accounting_api

--- a/spec/api_client_spec.rb
+++ b/spec/api_client_spec.rb
@@ -47,7 +47,7 @@ describe XeroRuby::ApiClient do
             state: 'i-am-customer-state'
           }
           api_client = XeroRuby::ApiClient.new(credentials: creds)
-          expect(api_client.authorization_url).to eq('https://login.xero.com/identity/connect/authorize?response_type=code&client_id=abc&redirect_uri=https://mydomain.com/callback&scope=openid+profile+email+accounting.transactions+accounting.settings&state=i-am-customer-state')
+          expect(api_client.authorization_url).to eq('https://login.xero.com/identity/connect/authorize?response_type=code&client_id=abc&redirect_uri=https%3A%2F%2Fmydomain.com%2Fcallback&scope=openid+profile+email+accounting.transactions+accounting.settings&state=i-am-customer-state')
         end
 
         it "Does not append state if it is not provided" do
@@ -58,7 +58,7 @@ describe XeroRuby::ApiClient do
             scopes: 'openid profile email accounting.transactions accounting.settings'
           }
           api_client = XeroRuby::ApiClient.new(credentials: creds)
-          expect(api_client.authorization_url).to eq('https://login.xero.com/identity/connect/authorize?response_type=code&client_id=abc&redirect_uri=https://mydomain.com/callback&scope=openid+profile+email+accounting.transactions+accounting.settings')
+          expect(api_client.authorization_url).to eq('https://login.xero.com/identity/connect/authorize?response_type=code&client_id=abc&redirect_uri=https%3A%2F%2Fmydomain.com%2Fcallback&scope=openid+profile+email+accounting.transactions+accounting.settings')
         end
 
         it "Validates state on callback matches @config.state" do


### PR DESCRIPTION
`CGI.escape` is deprecated in Ruby 2 and completely unsupported by ruby 3.

Fix missing URL encoding on the redirect_uri parameter.