### PR TITLE
Add missing expiring currencies

### DIFF
--- a/lib/xero-ruby/models/projects/currency_code.rb
+++ b/lib/xero-ruby/models/projects/currency_code.rb
@@ -38,6 +38,7 @@ module XeroRuby::Projects
     BTN ||= "BTN".freeze
     BWP ||= "BWP".freeze
     BYN ||= "BYN".freeze
+    BYR ||= "BYR".freeze
     BZD ||= "BZD".freeze
     CAD ||= "CAD".freeze
     CDF ||= "CDF".freeze
@@ -54,6 +55,7 @@ module XeroRuby::Projects
     DKK ||= "DKK".freeze
     DOP ||= "DOP".freeze
     DZD ||= "DZD".freeze
+    EEK ||= "EEK".freeze
     EGP ||= "EGP".freeze
     ERN ||= "ERN".freeze
     ETB ||= "ETB".freeze
@@ -99,6 +101,8 @@ module XeroRuby::Projects
     LKR ||= "LKR".freeze
     LRD ||= "LRD".freeze
     LSL ||= "LSL".freeze
+    LTL ||= "LTL".freeze
+    LVL ||= "LVL".freeze
     LYD ||= "LYD".freeze
     MAD ||= "MAD".freeze
     MDL ||= "MDL".freeze
@@ -107,11 +111,13 @@ module XeroRuby::Projects
     MMK ||= "MMK".freeze
     MNT ||= "MNT".freeze
     MOP ||= "MOP".freeze
+    MRO ||= "MRO".freeze
     MRU ||= "MRU".freeze
     MUR ||= "MUR".freeze
     MVR ||= "MVR".freeze
     MWK ||= "MWK".freeze
     MXN ||= "MXN".freeze
+    MXV ||= "MXV".freeze
     MYR ||= "MYR".freeze
     MZN ||= "MZN".freeze
     NAD ||= "NAD".freeze


### PR DESCRIPTION
Add missing expiring currencies to the list. If you add expiring currencies allowed via dashboard but not listed in the `CurrencyCode` class, such as Belarusian Ruble (BYR or Estonian Kroon (EEK) you no longer will be able to retrieve the account currency list via API using this library

![image (2)](https://user-images.githubusercontent.com/1730519/227529324-3a49eae5-00f4-447e-9318-66d4eb1f800a.png)

Fixes https://github.com/XeroAPI/xero-ruby/issues/250