### PR TITLE
Add expiring currencies

### DIFF
--- a/lib/xero-ruby/models/accounting/currency_code.rb
+++ b/lib/xero-ruby/models/accounting/currency_code.rb
@@ -55,6 +55,7 @@ module XeroRuby::Accounting
     DKK ||= "DKK".freeze
     DOP ||= "DOP".freeze
     DZD ||= "DZD".freeze
+    EEK ||= "EEK".freeze
     EGP ||= "EGP".freeze
     ERN ||= "ERN".freeze
     ETB ||= "ETB".freeze
@@ -101,6 +102,7 @@ module XeroRuby::Accounting
     LRD ||= "LRD".freeze
     LSL ||= "LSL".freeze
     LTL ||= "LTL".freeze
+    LVL ||= "LVL".freeze
     LYD ||= "LYD".freeze
     MAD ||= "MAD".freeze
     MDL ||= "MDL".freeze
@@ -109,11 +111,13 @@ module XeroRuby::Accounting
     MMK ||= "MMK".freeze
     MNT ||= "MNT".freeze
     MOP ||= "MOP".freeze
+    MRO ||= "MRO".freeze
     MRU ||= "MRU".freeze
     MUR ||= "MUR".freeze
     MVR ||= "MVR".freeze
     MWK ||= "MWK".freeze
     MXN ||= "MXN".freeze
+    MXV ||= "MXV".freeze
     MYR ||= "MYR".freeze
     MZN ||= "MZN".freeze
     NAD ||= "NAD".freeze


### PR DESCRIPTION
Add missing expiring accounting currencies to the list. If you add expiring currencies allowed via dashboard but not listed in the `CurrencyCode` class, such as Belarusian Ruble (BYR or Estonian Kroon (EEK) you no longer will be able to retrieve the account currency list via API using this library

![image (2)](https://user-images.githubusercontent.com/1730519/227529324-3a49eae5-00f4-447e-9318-66d4eb1f800a.png)

Fixes https://github.com/XeroAPI/xero-ruby/issues/250