### PR TITLE
up rev json-jwt in gemspec

### DIFF
--- a/lib/xero-ruby/version.rb
+++ b/lib/xero-ruby/version.rb
@@ -11,5 +11,5 @@ The version of the XeroOpenAPI document: 2.38.0
 =end
 
 module XeroRuby
-  VERSION = '4.3.0'
+  VERSION = '4.3.1'
 end

--- a/xero-ruby.gemspec
+++ b/xero-ruby.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'faraday', '>= 2.0', '< 3.0'
   s.add_runtime_dependency 'json', '~> 2.1', '>= 2.1.0'
-  s.add_runtime_dependency 'json-jwt', '~> 1.5', '>= 1.5.2'
+  s.add_runtime_dependency 'json-jwt', '~> 1.16', '>= 1.16.3'
   s.add_development_dependency 'rspec', '~> 3.6', '>= 3.6.0'
 
   s.files         = Dir.glob("{lib}/**/*") + %w(README.md)


### PR DESCRIPTION
XeroRuby gem not supporting operating systems running OpenSSL 3.0. Some changes have happened to how keys are handled. OpenSSL 3.0 is not new at this point and is included in major Linux operating systems like Debian Bookworm and Ubuntu 22.04 LTS.

The problem exists in the json-jwt gem that XeroRuby depends on and have a hard version dependance on in the 1.5.x.

The newest version supports OpenSSL 3.0