### PR TITLE
Upgrade ruby version to 2.6 and stop requiring JSON

### DIFF
--- a/xero-ruby.gemspec
+++ b/xero-ruby.gemspec
@@ -24,10 +24,9 @@ Gem::Specification.new do |s|
   s.summary     = "Xero Accounting API Ruby Gem"
   s.description = "Xero API OAuth2.0 SDK - Ruby Gem"
   s.license     = "Unlicense"
-  s.required_ruby_version = ">= 2.3"
+  s.required_ruby_version = ">= 2.6"
 
   s.add_runtime_dependency 'faraday', '>= 2.0', '< 3.0'
-  s.add_runtime_dependency 'json', '~> 2.1', '>= 2.1.0'
   s.add_runtime_dependency 'json-jwt', '~> 1.16', '>= 1.16.3'
   s.add_development_dependency 'rspec', '~> 3.6', '>= 3.6.0'
 


### PR DESCRIPTION
As of Ruby2.6, JSON is bundled with Ruby. Having it in the gemspec could cause version conflicts. We have faced this issues specifically with Puma in Cluster Mode. Where Puma loads the latest JSON version installed on the server, which would conflict with the JSON version in Gemfile.lock. This particularly happens on Upgrading our Downgrading JSON version, which renders Puma Phased Restarts and Hot Reload pointless.